### PR TITLE
Fix a type error.

### DIFF
--- a/src/vis.c
+++ b/src/vis.c
@@ -131,7 +131,7 @@ main(int argc, char **argv)
 		}
 		if (strcmp(p[0], "GET") == 0) {
 			valp = masstree_get(tree, key, strlen(key));
-			printf("%lu\n", (unsigned)(uintptr_t)valp);
+			printf("%lu\n", (unsigned long)(uintptr_t)valp);
 		}
 		if (strcmp(p[0], "DEL") == 0) {
 			masstree_del(tree, key, strlen(key));


### PR DESCRIPTION
When I compile in the latest version, I've got the following error:

```
$ make vis
gcc -std=gnu99 -O2 -flto -g -W -Wextra -Werror -D_BSD_SOURCE -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith -Wshadow -Wcast-qual -Wwrite-strings -O0 -DDEBUG -fno-omit-frame-pointer -fprofile-arcs -ftest-coverage   -c -o vis.o vis.c
vis.c: In function ‘main’:
vis.c:134:4: error: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘unsigned int’ [-Werror=format=]
    printf("%lu\n", (unsigned)(uintptr_t)valp);
    ^
cc1: all warnings being treated as errors
make: *** [vis.o] error 1
```

so made a tiny fix for it.